### PR TITLE
Document `Terminal.prototype.open` with `focus` argument

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: Terminal front-end component written in JavaScript that works in th
 baseurl: ""
 url: "http://xtermjs.org"
 
-version: "2.4.0"
+version: "2.5.0"
 
 markdown: kramdown
 

--- a/_docs/api/Terminal.md
+++ b/_docs/api/Terminal.md
@@ -181,17 +181,20 @@ Stop running a callback on an event.
 term.off('resize', logResize)
 ```
 
-### `open(parent)`
+### `open(parent, focus)`
 
 - `parent` - HTMLElement - The DOM element to host the terminal
+- `focus` - Boolean - Focus the terminal, after it gets instantiated in the DOM
 
-Open the terminal into the given parent element
+Open the terminal into the given parent element.
+
+> ⚠️  The `focus` argument currently defaults to `true` but starting with xterm.js 3.0 it will default to `false`.
 
 ```javascript
 var terminalParent = document.getElementById('xterm-container');
 
 // Expose the terminal into `terminalParent`.
-term.open(terminalParent);
+term.open(terminalParent, false);
 ```
 
 ### `refresh(start, end, queue)`


### PR DESCRIPTION
Also bump docs version to `2.5.0`