### PR TITLE
fixed spell mistake of function toggleFullScreen

### DIFF
--- a/_docs/api/addons/fullscreen.md
+++ b/_docs/api/addons/fullscreen.md
@@ -3,7 +3,7 @@ title: fullscreen
 category: addon
 ---
 
-The fullscreen addon provides the `toggleFullscreen` method that makes the terminal occupy the full viewport and back.
+The fullscreen addon provides the `toggleFullScreen` method that makes the terminal occupy the full viewport and back.
 
 > ⚠️ **Attention:** Do not forget to include [`addons/fullscreen/fullscreen.css`](https://github.com/sourcelair/xterm.js/blob/master/addons/fullscreen/fullscreen.css)!
 
@@ -17,13 +17,13 @@ var term = new Terminal();
 
 term.open(document.getElementById('terminal-container'));  // Open the terminal in #terminal-container
 
-term.toggleFullscreen();  // Now the terminal should occupy the full viewport
-term.toggleFullscreen();  // Now the terminal should be back to normal
+term.toggleFullScreen();  // Now the terminal should occupy the full viewport
+term.toggleFullScreen();  // Now the terminal should be back to normal
 ```
 
 ## Methods
 
-### `toggleFullscreen([fullscreen])`
+### `toggleFullScreen([fullscreen])`
 
 - `fullscreen` - Boolean - Whether to set the terminal to fullscreen mode or not
 
@@ -40,9 +40,9 @@ var term = new Terminal();
 
 term.open(document.getElementById('terminal-container'));  // Open the terminal in #terminal-container
 
-term.toggleFullscreen(true);  // Force terminal fullscreen mode
-term.toggleFullscreen(false);  // Force removal of terminal's fullscreen mode
+term.toggleFullScreen(true);  // Force terminal fullscreen mode
+term.toggleFullScreen(false);  // Force removal of terminal's fullscreen mode
 
 // ... user code ...
-term.toggleFullscreen()  // Toggle the terminal's fullscreen state
+term.toggleFullScreen()  // Toggle the terminal's fullscreen state
 ```


### PR DESCRIPTION
change all function toggleFullscreen to toggleFullScreen, the letter 'S' should be uppercase letter in version 3.x.