### PR TITLE
Fix some links in 'using addons' guide

### DIFF
--- a/_docs/guides/using-addons.md
+++ b/_docs/guides/using-addons.md
@@ -3,14 +3,14 @@ title: Using addons
 category: Guides
 ---
 
-Addons are JavaScript modules that attach functions to the [`Terminal`](/docs/api/Terminal/) prototype to extend its functionality.
+Addons are JavaScript modules that attach functions to the [`Terminal`](/docs/api/terminal/classes/terminal/) prototype to extend its functionality.
 
-There are a handful available in the main repository in the [`addons`](https://github.com/sourcelair/xterm.js/tree/master/addons/) directory, but you can even write your own by leveraging on the [xterm.js public API](/docs/).
+There are a handful available in the main repository in the [`addons`](https://github.com/sourcelair/xterm.js/tree/master/src/addons/) directory, but you can even write your own by leveraging on the [xterm.js public API](/docs/).
 
 To use an xterm.js addon, you have to:
 
 1. [import it](/docs/guides/import/) into your code
-2. pass it as argument to the static method [`Terminal.applyAddon`](/docs/api/Terminal/#applyaddonaddon-static-method)
+2. pass it as argument to the static method [`Terminal.applyAddon`](/docs/api/terminal/classes/terminal/#applyaddon)
 
 ## Example
 
@@ -19,6 +19,8 @@ import { Terminal } from 'xterm';
 import * as fit from 'xterm/lib/addons/fit/fit';
 
 Terminal.applyAddon(fit);
+
+let term = new Terminal();
 term.open(document.getElementById('#terminal'));
 
 term.fit();     // This method is now available for usage


### PR DESCRIPTION
Fixes some broken links and missing `term` declaration as mentioned in https://github.com/xtermjs/xterm.js/issues/1708

fixes xtermjs/xterm.js#1708