### PR TITLE
Add demo terminal

### DIFF
--- a/_includes/demo.html
+++ b/_includes/demo.html
@@ -1,0 +1,2 @@
+<h2 id="demo">Demo</h2>
+<div id="terminal"></div>

--- a/_includes/demo.html
+++ b/_includes/demo.html
@@ -1,2 +1,5 @@
 <h2 id="demo">Demo</h2>
 <div id="terminal"></div>
+<link rel="stylesheet" href="https://unpkg.com/xterm/dist/xterm.css" />
+<script src="https://unpkg.com/xterm/dist/xterm.js"></script>
+<script src="{{ "/js/demo.js" | prepend: site.baseurl }}"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,10 +19,20 @@
   <link rel="shortcut icon" type="image/png" href="{{ "/images/favicon.png" | prepend: site.baseurl }}" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600,700|Source+Sans+Pro:400,300,300italic,400italic,600,600italic,700,700italic' rel='stylesheet' type='text/css'>
+  {% if page.demo %}
+  <link rel="stylesheet" href="https://unpkg.com/xterm/dist/xterm.css" />
+  {% endif %}
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
   <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc=" crossorigin="anonymous"></script>
   <script src="https://use.fontawesome.com/47de3a5ce8.js"></script>
+  
+  {% if page.demo %}
+  <script src="https://unpkg.com/xterm/dist/xterm.js"></script>
+  <script src="{{ "/js/demo.js" | prepend: site.baseurl }}"></script>
+  {% endif %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,20 +19,10 @@
   <link rel="shortcut icon" type="image/png" href="{{ "/images/favicon.png" | prepend: site.baseurl }}" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" />
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600,700|Source+Sans+Pro:400,300,300italic,400italic,600,600italic,700,700italic' rel='stylesheet' type='text/css'>
-  {% if page.demo %}
-  <link rel="stylesheet" href="https://unpkg.com/xterm/dist/xterm.css" />
-  {% endif %}
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-
   <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc=" crossorigin="anonymous"></script>
   <script src="https://use.fontawesome.com/47de3a5ce8.js"></script>
-  
-  {% if page.demo %}
-  <script src="https://unpkg.com/xterm/dist/xterm.js"></script>
-  <script src="{{ "/js/demo.js" | prepend: site.baseurl }}"></script>
-  {% endif %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 permalink: /
-demo: true
 ---
 
 <div class="home">
@@ -14,8 +13,7 @@ demo: true
   {% capture getting_started %}{% include getting-started.md %}{% endcapture %}
   {{ getting_started | markdownify }}
 
-  {% capture demo %}{% include demo.html %}{% endcapture %}
-  {{ demo }}
+  {% include demo.html %}
 
   {% capture real_world_uses %}{% include real-world-uses.md %}{% endcapture %}
   {{ real_world_uses | markdownify }}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,18 +1,23 @@
 ---
 layout: default
 permalink: /
+demo: true
 ---
 
 <div class="home">
 
   <article>
-  	{% capture about %}{% include xtermjs-description.md %}{% endcapture %}
+    {% capture about %}{% include xtermjs-description.md %}{% endcapture %}
     {{ about | markdownify }}
   </article>
 
   {% capture getting_started %}{% include getting-started.md %}{% endcapture %}
   {{ getting_started | markdownify }}
 
+  {% capture demo %}{% include demo.html %}{% endcapture %}
+  {{ demo }}
+
   {% capture real_world_uses %}{% include real-world-uses.md %}{% endcapture %}
   {{ real_world_uses | markdownify }}
+
 </div>

--- a/js/demo.js
+++ b/js/demo.js
@@ -19,7 +19,7 @@ $(function () {
         term.writeln('');
         term.prompt();
 
-        term._core.register(term.addDisposableListener('key', (key, ev) => {
+        term.on('key', function(key, ev) {
             const printable = !ev.altKey && !ev.altGraphKey && !ev.ctrlKey && !ev.metaKey;
 
             if (ev.keyCode === 13) {
@@ -32,11 +32,11 @@ $(function () {
             } else if (printable) {
                 term.write(key);
             }
-        }));
+        });
 
-        term._core.register(term.addDisposableListener('paste', (data, ev) => {
+        term.on('paste', function(data) {
             term.write(data);
-        }));
+        });
     }
     runFakeTerminal();
 });

--- a/js/demo.js
+++ b/js/demo.js
@@ -1,0 +1,42 @@
+$(function () {
+    var term = new Terminal();
+    term.open(document.getElementById('terminal'));
+
+    function runFakeTerminal() {
+        if (term._initialized) {
+            return;
+        }
+
+        term._initialized = true;
+
+        term.prompt = () => {
+            term.write('\r\n$ ');
+        };
+
+        term.writeln('Welcome to xterm.js');
+        term.writeln('This is a local terminal emulation, without a real terminal in the back-end.');
+        term.writeln('Type some keys and commands to play around.');
+        term.writeln('');
+        term.prompt();
+
+        term._core.register(term.addDisposableListener('key', (key, ev) => {
+            const printable = !ev.altKey && !ev.altGraphKey && !ev.ctrlKey && !ev.metaKey;
+
+            if (ev.keyCode === 13) {
+                term.prompt();
+            } else if (ev.keyCode === 8) {
+                // Do not delete the prompt
+                if (term.x > 2) {
+                    term.write('\b \b');
+                }
+            } else if (printable) {
+                term.write(key);
+            }
+        }));
+
+        term._core.register(term.addDisposableListener('paste', (data, ev) => {
+            term.write(data);
+        }));
+    }
+    runFakeTerminal();
+});


### PR DESCRIPTION
Resolves #59 - Add an interactive terminal/demo on docs page

The demo uses the same code as the `runFakeTerminal` function in the demo in the xterm.js repository.

![image](https://user-images.githubusercontent.com/1689183/50349304-62168b80-0509-11e9-9c2d-80da3023257d.png)
