### PR TITLE
Giving table cells a little breathing room in docs

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -132,6 +132,10 @@ strong {
   margin-top: 20px;
 }
 
+.docs-content td:not(:last-child) {
+  padding-right: 1em;
+}
+
 h1, h2, h3, h4, h5, h6 {
   position: relative;
 


### PR DESCRIPTION
This especially fixes the table in https://xtermjs.org/docs/api/terminal/interfaces/iparser/ where cells have so much content that they runlikethis.