### PR TITLE
Fixed bottom-padding for table headers

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -132,8 +132,11 @@ strong {
   margin-top: 20px;
 }
 
-.docs-content tr:not(:last-child) {
-  td, th { padding-bottom: 0.5em; }
+.docs-content table {
+  th,
+  tr:not(:last-child) td {
+    padding-bottom: 0.5em;
+  }
 }
 
 .docs-content td:not(:last-child) {


### PR DESCRIPTION
It'll look weird of there's only `th`s and no `td`s, but that does't happen.