### PR TITLE
Update dependents link

### DIFF
--- a/_includes/real-world-uses.md
+++ b/_includes/real-world-uses.md
@@ -56,4 +56,4 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**NgTerminal**](https://github.com/qwefgh90/ng-terminal): NgTerminal is a web terminal that leverages xterm.js on Angular 7+. You can easily add it into your application by adding `<ng-terminal></ng-terminal>` into your component.
 - [**tty-share**](https://tty-share.com): Extremely simple terminal sharing over the Internet.
 
-[And much more...](https://github.com/xtermjs/xterm.js/network/dependents)
+[And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)


### PR DESCRIPTION
There aren't actually any packages that depend upon the GitHub repository. Therefore, the `dependents` endpoint does not show any results. This uses the URL for the `xterm` package.

I just happened to be looking at the website and noticed that.