### PR TITLE
Add CharCode Demo doesn't support

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -125,7 +125,7 @@ $(function () {
           }
           break;
         default: // Print all other characters for demo
-          if (e >= String.fromCharCode(0x20) && e <= String.fromCharCode(0x7B) || e >= '\u00a0') {
+          if (e >= String.fromCharCode(0x20) && e <= String.fromCharCode(0x7E) || e >= '\u00a0') {
             command += e;
             term.write(e);
           }


### PR DESCRIPTION
I can't use `}`, `|`, `~` in demo terminal.

so I add it.

0x7C = |
0x7D = }
0x7E = ~
