### PR TITLE
Add Render to list of xterm.js users

### DIFF
--- a/_includes/real-world-uses.md
+++ b/_includes/real-world-uses.md
@@ -55,5 +55,6 @@ Xterm.js is used in several world-class applications to provide great terminal e
 - [**PHP App Server**](https://github.com/cubiclesoft/php-app-server/): Create lightweight, installable almost-native applications for desktop OSes.  ExecTerminal (nicely wraps the xterm.js Terminal), TerminalManager, and RunProcessSDK are self-contained, reusable ES5+ compliant Javascript components.
 - [**NgTerminal**](https://github.com/qwefgh90/ng-terminal): NgTerminal is a web terminal that leverages xterm.js on Angular 7+. You can easily add it into your application by adding `<ng-terminal></ng-terminal>` into your component.
 - [**tty-share**](https://tty-share.com): Extremely simple terminal sharing over the Internet.
+- [**Render**](https://render.com): Platform-as-a-service for your apps, websites, and databases using xterm.js to provide a command prompt for user containers and for streaming build and runtime logs.
 
 [And much more...](https://github.com/xtermjs/xterm.js/network/dependents?package_id=UGFja2FnZS0xNjYzMjc4OQ%3D%3D)


### PR DESCRIPTION
Hello xterm.js folks- Thanks for creating and maintaining this great project. This PR adds [Render](https://render.com) to the list of xterm.js real world uses.

We have been using xterm.js for a few years to give our users a command prompt for their deployed container. We also use it to show streaming build and runtime logs for user services.

<img width="1286" alt="CleanShot 2022-06-24 at 10 41 48@2x" src="https://user-images.githubusercontent.com/275734/175614250-2ae45e61-62bf-4861-a647-6de96e010989.png">
