### PR TITLE
Force jekyll polling to get it working on WSL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "build:docs": "gulp docs",
-    "start": "bundle exec jekyll serve"
+    "start": "bundle exec jekyll serve --force_polling"
   },
   "devDependencies": {
     "@types/gulp": "^4.0.6",


### PR DESCRIPTION
Without this, the build task needed to be restarted every time on WSL in order to pick up changes.