### PR TITLE
Make build task a bg task with start/stop tracking

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,11 +4,32 @@
 		{
 			"type": "npm",
 			"script": "start",
-			"problemMatcher": [],
 			"label": "start",
 			"group": {
 				"kind": "build",
 				"isDefault": true
+			},
+			"isBackground": true,
+			"problemMatcher": {
+				"owner": "typescript",
+				"fileLocation": [
+					"relative",
+					"${workspaceFolder}"
+				],
+				"pattern": [
+				  {
+					// We don't track errors, only when the task is active
+					"regexp": "^fake problem matcher$",
+					"file": 1,
+					"location": 2,
+					"message": 3
+				  }
+				],
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "Regenerating:",
+					"endsPattern": "(Server running\\.\\.\\.|\\.\\.\\.done in .+ seconds)"
+				}
 			}
 		}
 	]


### PR DESCRIPTION
We get the spinner/check with this:

![image](https://github.com/xtermjs/xtermjs.org/assets/2193314/bc65768e-4f09-47d4-971a-41f2ed75e6bc)
