### PR TITLE
Use a wider container for npm install command

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -13,7 +13,7 @@
 
     .npm-install {
         display: flex;
-        width: 300px;
+        width: 370px;
         margin: auto;
         justify-content: space-between;
         background-color: #F8F8F8;


### PR DESCRIPTION
This increases the width for the element holding `npm install @xterm/xterm`.

After #205, the command occupies two lines. With a wider container, it occupies one line.

Before #205:

<img width="297" alt="before_205" src="https://github.com/xtermjs/xtermjs.org/assets/541289/52561105-e57f-4f77-8e7e-30e77d16ffe6">

After #205:

<img width="304" alt="after_205" src="https://github.com/xtermjs/xtermjs.org/assets/541289/c9b0bc84-2866-4e83-ac63-9aafa2a99f49">

After this PR:

<img width="354" alt="after_this_pr" src="https://github.com/xtermjs/xtermjs.org/assets/541289/c6320e38-efad-48ab-a238-e8bfc25a3d7f">
