### PR TITLE
Migrate all imports to new namespace

### DIFF
--- a/_docs/api/addons/attach.md
+++ b/_docs/api/addons/attach.md
@@ -8,8 +8,8 @@ The attach addon provides methods for attaching a terminal to a WebSocket stream
 This allows easy hooking of the terminal front-end to background processes and interact with it, just like you would do with in a local terminal. This means that the front-end terminal (a [`Terminal`](/docs/api/Terminal/) instance) will render the stdout and stderr logs of the back-end process and will send to it all keyboard and mouse events captured.
 
 ```ts
-import { Terminal } from 'xterm';
-import { AttachAddon } from 'xterm-addon-attach';
+import { Terminal } from '@xterm/xterm';
+import { AttachAddon } from '@xterm/addon-attach';
 
 const term = new Terminal();
 const socket = new WebSocket('wss://docker.example.com/containers/mycontainerid/attach/ws');

--- a/_docs/api/addons/fit.md
+++ b/_docs/api/addons/fit.md
@@ -6,8 +6,8 @@ category: addon
 The fit addon provides the `fit` method that lets you adjust the size and geometry (columns 𝗑 rows) of the terminal to fit the size of the parent element.
 
 ```ts
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
 
 const term = new Terminal();
 const fitAddon = new FitAddon();

--- a/_docs/guides/download.md
+++ b/_docs/guides/download.md
@@ -13,9 +13,10 @@ The best way to download xterm.js for use in your project is with [`npm`](http:/
 
 ```bash
 # Install with npm
-npm install --save xterm
+npm install @xterm/xterm
 
 # Or alternatively, install with Yarn
+yarn add @xterm/xterm
 ```
 
 ## GitHub Releases

--- a/_docs/guides/import.md
+++ b/_docs/guides/import.md
@@ -11,7 +11,7 @@ The preferred way to import xterm.js and its addons is the [`import` statement](
 
 ```javascript
 
-import { Terminal } from 'xterm';
+import { Terminal } from '@xterm/xterm';
 
 const term = new Terminal();
 

--- a/_docs/guides/using-addons.md
+++ b/_docs/guides/using-addons.md
@@ -15,8 +15,8 @@ To use an xterm.js addon, you have to:
 ## Usage example
 
 ```ts
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
 
 const term = new Terminal();
 const fitAddon = new FitAddon();
@@ -34,7 +34,7 @@ fitAddon.fit();
 Creating an addon is quite simple, you just need to export some object that has an `activate` and `dispose` method. The following addon logs any `onData` events coming from the terminal which fire when the user types:
 
 ```ts
-import { Terminal, IDisposable } from 'xterm';
+import { Terminal, IDisposable } from '@xterm/xterm';
 
 class DataLoggerAddon {
   private _disposables: IDisposable[] = [];


### PR DESCRIPTION
This PR:

- Updates the install command to the new namespaced package
- Removes the old `--save` flag from NPM install command
- Adds the missing `yarn` install command
- Updates the API docs to the new namespaced packages
- Updates the guides docs to the new namespaced packages